### PR TITLE
Fix GitHub raw file access

### DIFF
--- a/git-license
+++ b/git-license
@@ -4,7 +4,7 @@ dest="$(git rev-parse --show-toplevel)/LICENSE"
 
 function fetch_license()
 {
-  curl https://raw.github.com/lucperkins/licenses/master/$1.txt > $dest
+  curl https://raw.githubusercontent.com/lucperkins/licenses/master/$1.txt > $dest
 }
 
 case $1 in


### PR DESCRIPTION
GitHub changed changed the raw access URL to the raw.githubusercontent.com domain.
